### PR TITLE
turn off se linux for now

### DIFF
--- a/include/ioc.yml
+++ b/include/ioc.yml
@@ -14,6 +14,9 @@ services:
       # should be (used by machine IOCs) this is for parity (but redundant).
       location: localhost
 
+    security_opt:
+      - label=disable
+
     # NOTE: blank environment vars should be overriden in individual IOCs
     environment:
       IOCSH_PS1:

--- a/services/gateway/compose.yml
+++ b/services/gateway/compose.yml
@@ -19,6 +19,9 @@ services:
       - 5064-5065/udp
       - 5064-5065
 
+    security_opt:
+      - label=disable
+
     ports:
       # bind to localhost to isolate channel access to this host only
       - 127.0.0.1:5064:5064/udp

--- a/services/phoebus/compose.yml
+++ b/services/phoebus/compose.yml
@@ -16,6 +16,9 @@ services:
       - ../../opi:/opi
       - ../../..:/workspaces
 
+    security_opt:
+      - label=disable
+
     # for X11 to work we need to run as the same UID as the host
     # IMPORTANT: set UIDGID to your host user:group e.g. 1000:1000
     # BUT: always to 0:0 if you are using podman


### PR DESCRIPTION
This makes the example work on Rocky Linux appliance for EPICS 7 training with no extra config for podman. It would also mean we don't need to globally turn off se linux at DLS (but that may still be needed for developer containers?? - not sure - they might have fixed that in the devcontainer extension)