### PR TITLE
use .env and init container

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
-# Environment variables for the EPICS IOC ports. Pick a Unique values
+# Environment variables for the EPICS IOC ports. Pick unique values
 # to allow multiple compose beamlines to run on the same host.
 EPICS_CA_SERVER_PORT=5094
 EPICS_CA_REPEATER_PORT=5095
 EPICS_PVA_SERVER_PORT=5105
 
-# unique subnet for this compose project
+# unique subnet for this compose project, broadcast must match the subnet
 CA_SUBNET=170.200.0.0/16
 CA_BROADCAST=170.200.255.255
 

--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+# Environment variables for the EPICS IOC ports. Pick a Unique values
+# to allow multiple compose beamlines to run on the same host.
+EPICS_CA_SERVER_PORT=5094
+EPICS_CA_REPEATER_PORT=5095
+EPICS_PVA_SERVER_PORT=5105
+
+# unique subnet for this compose project
+CA_SUBNET=170.200.0.0/16
+CA_BROADCAST=170.200.255.255
+
+# EPICS name server configuration - do not change
+EPICS_PVA_NAME_SERVERS=localhost:${EPICS_PVA_SERVER_PORT}
+EPICS_CA_NAME_SERVERS=localhost:${EPICS_CA_SERVER_PORT}
+
+# clients outside of containers should use this address list
+# to access local containers with this configuration and with default ports too
+EPICS_CA_ADDR_LIST="127.0.0.1:${EPICS_PVA_SERVER_PORT} 127.0.0.1:5064"

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,3 +27,22 @@ include:
 
   # deploy profile only
   - services/epics-opis/compose.yml
+
+services:
+  init:
+    image: ubuntu
+    security_opt:
+      - label=disable
+    restart: never
+    volumes:
+      - .:/workspace
+    command: /bin/bash -c "/workspace/include/init.sh"
+    environment:
+      - EPICS_CA_SERVER_PORT
+      - EPICS_CA_REPEATER_PORT
+      - EPICS_PVA_SERVER_PORT
+      - CA_SUBNET
+      - CA_BROADCAST
+      - EPICS_PVA_NAME_SERVERS
+      - EPICS_CA_NAME_SERVERS
+      - EPICS_CA_ADDR_LIST

--- a/environment.sh
+++ b/environment.sh
@@ -7,39 +7,11 @@
 # docker compose may be backed by podman or docker container engines, see
 # https://epics-containers.github.io/main/tutorials/setup_workstation.html.
 
-
 # This script must be sourced
 if [ "$0" = "$BASH_SOURCE" ]; then
     echo "ERROR: Please source this script (source ./environment.sh)"
     exit 1
 fi
-
-# Environment variables for the EPICS IOC ports. Pick a Unique BASE
-# to allow multiple compose beamlines to run on the same host.
-# BASE values should be separated by 20.
-#
-BASE=5094 # default would usually be 5064
-#
-export EPICS_CA_SERVER_PORT=$BASE # default 5064
-export EPICS_CA_REPEATER_PORT=$(( $BASE + 1 )) # default 5065
-export EPICS_PVA_SERVER_PORT=$(( $BASE + 11 )) # default 5075
-
-export CA_SUBNET=170.$(( $BASE % 256 )).0.0/16
-export CA_BROADCAST=170.$(( $BASE % 256 )).255.255
-
-export EPICS_PVA_NAME_SERVERS=localhost:${EPICS_PVA_SERVER_PORT}
-export EPICS_CA_NAME_SERVERS=localhost:${EPICS_CA_SERVER_PORT}
-
-export EPICS_CA_ADDR_LIST=127.0.0.1
-
-# update configuration files that depend on the above environment variables
-cat services/phoebus/config/settings.template |
-  sed -e "s/5064/$EPICS_CA_SERVER_PORT/g" \
-      -e "s/5065/$EPICS_CA_REPEATER_PORT/g" \
-      -e "s/5075/$EPICS_PVA_SERVER_PORT/g" > services/phoebus/config/settings.ini
-cat services/pvagw/config/pvagw.template |
-  sed -e "s/172.20.255.255/$CA_BROADCAST/g" \
-      -e "s/5075/$EPICS_PVA_SERVER_PORT/g" > services/pvagw/config/pvagw.config
 
 # if there is a docker-compose module then load it
 if [[ $(module avail docker-compose 2>/dev/null) != "" ]] ; then
@@ -65,7 +37,7 @@ xhost +SI:localuser:$(id -un)
 
 # set user id for the phoebus container for easy X11 forwarding.
 export UIDGID=$USER_ID:$USER_GID
-# choose test profile for docker compose
+# default to the test profile for docker compose
 export COMPOSE_PROFILES=test
 # for test profile our ca-gateway publishes PVS on the loopback interface
 export EPICS_CA_ADDR_LIST=127.0.0.1

--- a/include/init.sh
+++ b/include/init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+root=$(realpath $(dirname $0)/..)
+
+echo "setting up configuration file for pva gateway"
+
+cat $root/services/pvagw/config/pvagw.template |
+  sed -e "s/172.20.255.255/$CA_BROADCAST/g" \
+      -e "s/5075/$EPICS_PVA_SERVER_PORT/g" > \
+      $root/services/pvagw/config/pvagw.config
+
+echo "setting up configuration file for phoebus"
+
+cat $root/services/phoebus/config/settings.template |
+  sed -e "s/5064/$EPICS_CA_SERVER_PORT/g" \
+      -e "s/5065/$EPICS_CA_REPEATER_PORT/g" \
+      -e "s/5075/$EPICS_PVA_SERVER_PORT/g" > \
+      $root/services/phoebus/config/settings.ini

--- a/services/phoebus/compose.yml
+++ b/services/phoebus/compose.yml
@@ -9,6 +9,8 @@ services:
       - init
     environment:
       DISPLAY: $DISPLAY
+      UIDGID: ${UIDGID:-0:0} # defaults to working with rootless
+
     tty: true
     # pick a server port for phoebus so it does not reconnect to existing phoebus
     command: phoebus-product/phoebus.sh -settings /config/settings.ini -resource /opi/demo.bob -server 7010

--- a/services/phoebus/compose.yml
+++ b/services/phoebus/compose.yml
@@ -5,6 +5,8 @@ services:
   phoebus:
     container_name: phoebus
     image: ghcr.io/epics-containers/ec-phoebus:4.7.3ec2
+    depends_on:
+      - init
     environment:
       DISPLAY: $DISPLAY
     tty: true

--- a/services/pvagw/compose.yml
+++ b/services/pvagw/compose.yml
@@ -9,6 +9,9 @@ services:
 
     image: ghcr.io/epics-containers/ec-p4p:4.1.12ec1
 
+    depends_on:
+      - init
+
     security_opt:
       - label=disable
 


### PR DESCRIPTION
tidy up the configurable version of example-services by using a .env file and init container.

With the addition of a default value for UIDGID we now have the project fully described in compose yaml. The environment.sh script is a convenience but at DLS you can launch the project without that file using these commands:
```
module load docker-compose
docker compose --profile test up -d
```

This achieves my goal of making this a "pure" docker compose implementation.