### PR TITLE
Non root docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,10 @@ venv*
 .venv*
 *workspace
 
-# this is the root directory for generated opi files
-# and is created at runtime by IOCs using PVI
+# these files are generated at runtime by IOC containers
 opi/auto-generated/*
-!opi/auto-generated/README.md
-
 autosave/*
-!autosave/.placeholder
+runtime/*
 
 # these files are generated from templates
 # when sourcing environment.sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,3 +46,6 @@ services:
       - EPICS_PVA_NAME_SERVERS
       - EPICS_CA_NAME_SERVERS
       - EPICS_CA_ADDR_LIST
+
+    # run with same ID as the user (for docker - for podman run as root)
+    user: ${UIDGID}

--- a/include/init.sh
+++ b/include/init.sh
@@ -23,3 +23,4 @@ for ioc in bl01t-di-cam-01 bl01t-ea-test-01 bl01t-mo-sim-01; do
   mkdir -p $root/autosave/$ioc
   mkdir -p $root/runtime/$ioc
   mkdir -p $root/opi/auto-generated/$ioc
+done

--- a/include/init.sh
+++ b/include/init.sh
@@ -16,3 +16,10 @@ cat $root/services/phoebus/config/settings.template |
       -e "s/5065/$EPICS_CA_REPEATER_PORT/g" \
       -e "s/5075/$EPICS_PVA_SERVER_PORT/g" > \
       $root/services/phoebus/config/settings.ini
+
+# this is a workaround for docker creating host mounts as root if they don't exist:
+# not required for podman but benign
+for ioc in bl01t-di-cam-01 bl01t-ea-test-01 bl01t-mo-sim-01; do
+  mkdir -p $root/autosave/$ioc
+  mkdir -p $root/runtime/$ioc
+  mkdir -p $root/opi/auto-generated/$ioc

--- a/include/ioc.yml
+++ b/include/ioc.yml
@@ -14,6 +14,9 @@ services:
       # should be (used by machine IOCs) this is for parity (but redundant).
       location: localhost
 
+    # run with same ID as the user (for docker - for podman run as root)
+    user: ${UIDGID}
+
     security_opt:
       - label=disable
 

--- a/include/ioc.yml
+++ b/include/ioc.yml
@@ -5,6 +5,10 @@
 services:
   # linux IOCs that run in a container #########################################
   linux_ioc: &linux_ioc
+    depends_on:
+      init:
+        condition: service_completed_successfully
+
     labels:
       # a reference to which repository created this IOC
       ioc_group: bl01t

--- a/services/bl01t-di-cam-01/compose.yml
+++ b/services/bl01t-di-cam-01/compose.yml
@@ -22,8 +22,7 @@ services:
     volumes:
       - ../../opi/auto-generated/bl01t-di-cam-01:/epics/opi
       - ../../autosave/bl01t-di-cam-01:/autosave
-      # FOR DEVCONTAINERS: mount in the parent of the project
-      - ../../..:/workspaces
+      - ../../runtime/bl01t-di-cam-01:/epics/runtime
 
     configs:
       - source: bl01t-di-cam-01_config
@@ -36,6 +35,10 @@ services:
   bl01t-di-cam-01-dev:
     <<: *bl01t-di-cam-01
     image: ghcr.io/epics-containers/ioc-adsimdetector-developer:2025.3.5
+
+    volumes:
+      # FOR DEVCONTAINERS: mount in the parent of the project
+      - ../../..:/workspaces
 
     profiles:
       - devcontainer

--- a/services/bl01t-ea-test-01/compose.yml
+++ b/services/bl01t-ea-test-01/compose.yml
@@ -16,6 +16,9 @@ services:
       IOC_NAME: bl01t-ea-test-01
       IOC_PREFIX: BL01T-EA-TEST-01
 
+    volumes:
+      - ../../runtime/bl01t-ea-test-01:/epics/runtime
+
     configs:
       - source: bl01t-ea-test-01_config
         target: epics/ioc/config

--- a/services/bl01t-mo-sim-01/compose.yml
+++ b/services/bl01t-mo-sim-01/compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ../../opi/auto-generated/bl01t-mo-sim-01:/epics/opi
       - ../../autosave/bl01t-mo-sim-01:/autosave
+      - ../../runtime/bl01t-mo-sim-01:/epics/runtime
 
     configs:
       - source: bl01t-mo-sim-01_config

--- a/services/gateway/compose.yml
+++ b/services/gateway/compose.yml
@@ -15,6 +15,9 @@ services:
 
     image: ghcr.io/epics-containers/gateways-runtime:2024.12.3
 
+    # run with same ID as the user (for docker - for podman run as root)
+    user: ${UIDGID}
+
     security_opt:
       - label=disable
 

--- a/services/pvagw/compose.yml
+++ b/services/pvagw/compose.yml
@@ -12,6 +12,9 @@ services:
     depends_on:
       - init
 
+    # run with same ID as the user (for docker - for podman run as root)
+    user: ${UIDGID}
+
     security_opt:
       - label=disable
 


### PR DESCRIPTION
- Run IOCs as UIDGID 
- create all host mounts in init process to avoid compose making them root owned
- make IOCs depend on init completion
- add runtime mount so it is writable to non root user at container runtime