### PR TITLE
use http for bob files

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,7 @@ include:
   - services/bl01t-mo-sim-01/compose.yml
   - services/gateway/compose.yml
   - services/pvagw/compose.yml
+  - services/epics-opis/compose.yml
 
   # develop profile only
   - services/phoebus/compose.yml

--- a/services/epics-opis/compose.yml
+++ b/services/epics-opis/compose.yml
@@ -8,17 +8,21 @@
 services:
 
   epics-opis:
-    image: docker.io/nginx:1.27
+    image: docker.io/nginx:1.27.5
 
     restart: unless-stopped
 
-    networks:
-      - channel_access
-
     volumes:
-      - ../opi:/opi
+      # mount this project's /opis into default nginx static html folder
+      - ../../opi:/usr/share/nginx/html/opi
+      - ./config/nginx.conf:/etc/nginx/nginx.conf
 
     platform: linux/amd64
 
+    # expose http port 80 on host's 8001 (all NICs)
+    ports:
+      - 8001:80
+
     profiles:
       - deploy
+      - test

--- a/services/phoebus/compose.yml
+++ b/services/phoebus/compose.yml
@@ -13,7 +13,7 @@ services:
 
     tty: true
     # pick a server port for phoebus so it does not reconnect to existing phoebus
-    command: phoebus-product/phoebus.sh -settings /config/settings.ini -resource /opi/demo.bob -server 7010
+    command: phoebus-product/phoebus.sh -settings /config/settings.ini -resource http://localhost:8001/opi/demo.bob -server 7010
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ~/.Xauthority:/root/.Xauthority


### PR DESCRIPTION
- adds the epics-opis service which serves the opis folder over http
- update phoebus launch to use http for its bobs