### PR TITLE
Update containers to latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker compose up bl01t-di-cam-01 -d
 docker compose down
 ```
 
-NOTE: sometimes the pva-gateway will not terminate before `docker compose down` completes. If this happens then you can run `docker compose down` again and it should then remove the pva-gateway container.
+NOTE: sometimes the pva-gateway will not terminate before `docker compose down` times out and you will see an error. If this happens then you can run `docker compose down` again and it should then remove the pva-gateway container.
 
 # Deploy To Beamline Servers
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ docker compose up bl01t-di-cam-01 -d
 docker compose down
 ```
 
+NOTE: sometimes the pva-gateway will not terminate before `docker compose down` completes. If this happens then you can run `docker compose down` again and it should then remove the pva-gateway container.
+
 # Deploy To Beamline Servers
 
 TODO: although this will work for CA, there is not yet a solution for PVA. PVA UDP traffic will not route into a container. Two possible solutions are:

--- a/services/bl01t-di-cam-01/compose.yml
+++ b/services/bl01t-di-cam-01/compose.yml
@@ -6,7 +6,7 @@ services:
       service: linux_ioc
       file: ../../include/ioc.yml
 
-    image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.4.2b1
+    image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.7.1b2
 
     labels:
       version: 0.1.0
@@ -35,7 +35,7 @@ services:
 
   bl01t-di-cam-01-dev:
     <<: *bl01t-di-cam-01
-    image: ghcr.io/epics-containers/ioc-adsimdetector-developer:2025.3.5
+    image: ghcr.io/epics-containers/ioc-adsimdetector-developer:2025.7.1b2
 
     profiles:
       - devcontainer

--- a/services/bl01t-di-cam-01/config/ioc.yaml
+++ b/services/bl01t-di-cam-01/config/ioc.yaml
@@ -28,11 +28,11 @@ entities:
       dbpf BL01T-DI-CAM-01:PVA:EnableCallbacks 1
       dbpf BL01T-DI-CAM-01:DET:Acquire 1
 
-  - type: ffmpegServer.ffmpegStream
-    PORT: DET.MJP
-    P: BL01T-DI-CAM-01
-    R: ":MJP:"
-    NDARRAY_PORT: DET.DET
+  # - type: ffmpegServer.ffmpegStream
+  #   PORT: DET.MJP
+  #   P: BL01T-DI-CAM-01
+  #   R: ":MJP:"
+  #   NDARRAY_PORT: DET.DET
 
   - type: ADCore.NDROI
     PORT: DET.ROI

--- a/services/bl01t-di-cam-01/config/ioc.yaml
+++ b/services/bl01t-di-cam-01/config/ioc.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://github.com/epics-containers/ioc-adsimdetector/releases/download/2025.3.4/ibek.ioc.schema.json
+# yaml-language-server: $schema=https://github.com/epics-containers/ioc-adsimdetector/releases/download/2025.7.1b2/ibek.ioc.schema.json
 
 ioc_name: "{{ _global.get_env('IOC_NAME') }}"
 description: Example simulated camera for BL01T
@@ -46,7 +46,7 @@ entities:
     R: ":PROC:"
     NDARRAY_PORT: DET.ROI
 
-  - type: ADCore.NDPvaPlugin
+  - type: ADCore.NDPvxsPlugin
     PORT: DET.PVA
     PVNAME: BL01T-DI-CAM-01:PVA:OUTPUT
     P: BL01T-DI-CAM-01

--- a/services/bl01t-mo-sim-01/compose.yml
+++ b/services/bl01t-mo-sim-01/compose.yml
@@ -6,7 +6,7 @@ services:
       service: linux_ioc
       file: ../../include/ioc.yml
 
-    image: ghcr.io/epics-containers/ioc-motorsim-runtime:2025.7.2
+    image: ghcr.io/epics-containers/ioc-motorsim-runtime:2025.7.3b1
 
     labels:
       version: 0.1.0

--- a/services/bl01t-mo-sim-01/compose.yml
+++ b/services/bl01t-mo-sim-01/compose.yml
@@ -6,7 +6,7 @@ services:
       service: linux_ioc
       file: ../../include/ioc.yml
 
-    image: ghcr.io/epics-containers/ioc-motorsim-runtime:2025.3.1
+    image: ghcr.io/epics-containers/ioc-motorsim-runtime:2025.7.2
 
     labels:
       version: 0.1.0


### PR DESCRIPTION
This updates the motor and AD simulation IOCs as follows:-

- both are now based on the new ubuntu-devcontainer project container image that uses `uv` instead of `pip` see https://github.com/DiamondLightSource/ubuntu-devcontainer
- AD now uses the latest ADCore and uses pvxs for serving PVA instead of the older PVA libraries
- a new version of ffmpegServer fixes the crash when rendering mono 8bit images

`ffmpegServer.Stream` has been removed from the `bl01t-di-cam-01` instance because it makes the IOC timeout during shutdown (minor irritation only). Un-comment from ioc.yaml to restore.

