### PR TITLE
fix epics-opis - remove :z as label=disable already applied

### DIFF
--- a/services/epics-opis/compose.yml
+++ b/services/epics-opis/compose.yml
@@ -14,8 +14,8 @@ services:
 
     volumes:
       # mount this project's /opis into default nginx static html folder
-      - ../../opi:/usr/share/nginx/html/opi:z
-      - ./config/nginx.conf:/etc/nginx/nginx.conf:z
+      - ../../opi:/usr/share/nginx/html/opi
+      - ./config/nginx.conf:/etc/nginx/nginx.conf
 
     security_opt:
       - label=disable


### PR DESCRIPTION
This fixes the issue where we see 
```
Error response from daemon: lsetxattr /home/hgv27681/example-services/opi/README.md: operation not supported
```

When trying to launch in a DLS home directory.